### PR TITLE
Update and optionally install apparmor profile (#549)

### DIFF
--- a/contrib/usr.bin.ricochet-apparmor
+++ b/contrib/usr.bin.ricochet-apparmor
@@ -1,43 +1,51 @@
+# Last Modified: Mon Jul 17 00:25:38 2017
+#include <tunables/global>
+
 # AppArmor Ricochet profile for Debian GNU/Linux
 # This profile is Free Software and released under the same license as Ricochet
 # itself.
 #
 # Copyleft 2015 Jacob Appelbaum <jacob@appelbaum.net>
 #
-#include <tunables/global>
+
 
 /usr/bin/ricochet {
+  #include <abstractions/audio>
   #include <abstractions/kde>
   #include <abstractions/nameservice>
-  #include <abstractions/audio>
+
+  /usr/lib/** mr,
 
   # Allow TCP connections
   network inet stream,
   network inet6 stream,
 
-  /usr/lib/** mr,
-
   # Allow Ricochet to exec pulseaudio
   # This makes me very sad...
   # as it seems that you can't isolate playing and recording :(
-  /usr/bin/pulseaudio ixr,
+  /usr/bin/pulseaudio rix,
 
   # Allow Ricochet to exec tor
-  /usr/bin/tor ixr,
+  /usr/bin/tor rix,
+  # Tor in turn needs various things
   /usr/share/tor/geoip  r,
   /usr/share/tor/geoip6 r,
-  # Tor in turn needs various things
   /proc/sys/kernel/random/uuid r,
   /sys/devices/system/cpu/ r,
+  # Allow Ricochet to read tor daemons auth cookie
+  /run/tor/control.authcookie r,
 
   # Allow Ricochet to read itself
   /usr/bin/ricochet r,
   /proc/[0-9]*/cmdline r,
+  /proc/[0-9]*/environ r,
 
   # Allow Ricochet to generate audio
   owner /{dev,run}/shm/pulse-shm* m,
 
   # Allow Ricochet to draw the UX
+  /dev/dri/ r,
+  /sys/devices/pci[0-9]*/**/config r,
   /sys/devices/pci[0-9]*/**/uevent r,
   /run/udev/data/* r,
 
@@ -50,8 +58,7 @@
   # Why does it need this stuff? BAD NEWS BEARS
   /etc/machine-id r,
   /var/lib/dbus/machine-id r,
-  /etc/udev/udev.conf r,
 
   owner @{HOME}/.local/share/Ricochet/ rw,
-  owner @{HOME}/.local/share/Ricochet/** rwmk,
+  owner @{HOME}/.local/share/Ricochet/** mrwk,
 }

--- a/ricochet.pro
+++ b/ricochet.pro
@@ -60,6 +60,18 @@ contains(DEFINES, RICOCHET_NO_PORTABLE) {
         scalable_icon.path = /usr/share/icons/hicolor/scalable/apps/
         scalable_icon.files = icons/ricochet.svg
         INSTALLS += target shortcut icon scalable_icon
+        QMAKE_CLEAN += contrib/usr.bin.ricochet
+        contains(DEFINES, APPARMOR) {
+            apparmor_profile.extra = cp -f $${_PRO_FILE_PWD_}/contrib/usr.bin.ricochet-apparmor $${_PRO_FILE_PWD_}/contrib/usr.bin.ricochet
+            apparmor_profile.files = contrib/usr.bin.ricochet
+            QMAKE_CLEAN += contrib/usr.bin.ricochet
+            !isEmpty(APPARMORDIR) {
+                    apparmor_profile.path = $${APPARMORDIR}/
+            } else {
+                    apparmor_profile.path = /etc/apparmor.d/
+            }
+            INSTALLS += apparmor_profile
+        }
 
         exists(tor) {
             message(Adding bundled Tor to installations)


### PR DESCRIPTION
* Update usr.bin.ricochet-apparmor

needs access to /sys/devices.../config for some graphics cards (i915 it seems, in my case), access to /proc/$PID/environ to read envvars (e.g. TOR_CONTROL_PORT), access to Tor's Control Cookie file to authenticate. Strangely also /dev/dri/ to draw the UX (not covered by <abstractions/X>?) Updated with `aa-genprof`, tested under Tails 3.0.1 and Debian Stretch desktop.

The apparmor profile can be installed in `make install` by passing `DEFINES+=APPARMOR`, and optionally `APPARMORDIR=/path/`.